### PR TITLE
Release v0.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ cache:
     - $HOME/.gradle/wrapper/
 
 jdk:
-  - openjdk7
   - oraclejdk8
   - openjdk8
   - oraclejdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ cache:
     - $HOME/.gradle/wrapper/
 
 jdk:
+  - openjdk7
   - oraclejdk8
   - openjdk8
   - oraclejdk11

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FatturaPA Model [![Build Status](https://travis-ci.com/siboXD/fatturapa-model.svg?branch=master)](https://travis-ci.com/siboXD/fatturapa-model) [![Release](https://jitpack.io/v/siboxd/fatturapa-model.svg)](https://jitpack.io/#siboxd/fatturapa-model) [![License: MIT](https://img.shields.io/badge/License-MIT-lightgray.svg)](https://github.com/siboXD/fatturapa-model/blob/master/LICENSE)
-Model classes for Italian Elotronic Invoicing ([Fatturazione Elettronica](https://www.fatturapa.gov.it/export/fatturazione/it/normativa/f-2.htm)) with annotations to be transformed to XML format thanks to [SimpleXML](http://simple.sourceforge.net/) framework.
+Model classes for Italian Electronic Invoicing ([Fatturazione Elettronica](https://www.fatturapa.gov.it/export/fatturazione/it/normativa/f-2.htm)) with annotations to be transformed to XML format thanks to [SimpleXML](http://simple.sourceforge.net/) framework.
 
 ## Work in progress...
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 dependencies {
     implementation 'org.simpleframework:simple-xml:2.7.1'
 
-    implementation 'com.google.guava:guava:27.0.1-jre'
+    implementation 'org.checkerframework:checker-qual-android:2.5.8'
     implementation 'org.apache.commons:commons-lang3:3.8.1'
     implementation 'commons-io:commons-io:2.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group 'com.github.siboxd'
 version '0.3.0'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.7
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation 'org.simpleframework:simple-xml:2.7.1'
 
     implementation 'org.checkerframework:checker-qual-android:2.5.8'
-    implementation 'org.apache.commons:commons-lang3:3.8.1'
     implementation 'commons-io:commons-io:2.6'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'

--- a/src/main/java/com/github/siboxd/fatturapa/model/utils/Lists.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/utils/Lists.java
@@ -20,6 +20,6 @@ public final class Lists {
      * @return the copy of the list, or an empty list if provided parameter is null
      */
     public static <T> List<T> defensiveCopy(@Nullable final List<? extends T> toCopy) {
-        return toCopy != null ? new ArrayList<>(toCopy) : new ArrayList<>();
+        return toCopy != null ? new ArrayList<>(toCopy) : new ArrayList<T>();
     }
 }

--- a/src/test/java/com/github/siboxd/fatturapa/model/FatturaElettronicaSerializationRoundTripTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/FatturaElettronicaSerializationRoundTripTest.java
@@ -1,7 +1,6 @@
 package com.github.siboxd.fatturapa.model;
 
 import com.github.siboxd.fatturapa.testutils.AbstractXmlSerializationTest;
-import com.google.common.collect.Streams;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -14,6 +13,8 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,7 +27,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *
  * @author Enrico
  */
-@SuppressWarnings("UnstableApiUsage")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FatturaElettronicaSerializationRoundTripTest extends AbstractXmlSerializationTest {
 
@@ -62,12 +62,21 @@ class FatturaElettronicaSerializationRoundTripTest extends AbstractXmlSerializat
 
     @Test
     void serializationRoundTripTest() {
-        Streams.forEachPair(
-                parseInvoicesInFolder(invoicesFolderPath),
-                getInvoicesFromFolder(invoicesFolderPath).stream().map(File::toPath).map(invoicesFolderPath::relativize),
+        final List<Path> invoicesPaths = getInvoicesFromFolder(invoicesFolderPath)
+                .stream()
+                .map(File::toPath)
+                .map(invoicesFolderPath::relativize)
+                .collect(Collectors.toList());
 
-                (parsedInvoice, expectedXmlInvoiceFilePath) ->
-                        persistAndCheck(parsedInvoice, INVOICES_RESOURCE_FOLDER, expectedXmlInvoiceFilePath.toString()));
+        final List<FatturaElettronica> parsedInvoices = parseInvoicesInFolder(invoicesFolderPath)
+                .collect(Collectors.toList());
+
+        for (int i = 0; i < invoicesPaths.size(); i++) {
+            final String expectedXmlInvoiceFilePath = invoicesPaths.get(i).toString();
+            final FatturaElettronica parsedInvoice = parsedInvoices.get(i);
+
+            persistAndCheck(parsedInvoice, INVOICES_RESOURCE_FOLDER, expectedXmlInvoiceFilePath);
+        }
     }
 
     /**

--- a/src/test/java/com/github/siboxd/fatturapa/model/FatturaElettronicaSerializationRoundTripTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/FatturaElettronicaSerializationRoundTripTest.java
@@ -12,11 +12,11 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -57,19 +57,17 @@ class FatturaElettronicaSerializationRoundTripTest extends AbstractXmlSerializat
 
     @Test
     void deserializeXmlInvoices() {
-        assertEquals(parseInvoicesInFolder(invoicesFolderPath).count(), numberOfInvoicesExamples);
+        assertEquals(parseInvoicesInFolder(invoicesFolderPath).size(), numberOfInvoicesExamples);
     }
 
     @Test
     void serializationRoundTripTest() {
-        final List<Path> invoicesPaths = getInvoicesFromFolder(invoicesFolderPath)
-                .stream()
-                .map(File::toPath)
-                .map(invoicesFolderPath::relativize)
-                .collect(Collectors.toList());
+        final List<Path> invoicesPaths = new ArrayList<>();
+        for (final File file : getInvoicesFromFolder(invoicesFolderPath)) {
+            invoicesPaths.add(invoicesFolderPath.relativize(file.toPath()));
+        }
 
-        final List<FatturaElettronica> parsedInvoices = parseInvoicesInFolder(invoicesFolderPath)
-                .collect(Collectors.toList());
+        final List<FatturaElettronica> parsedInvoices = parseInvoicesInFolder(invoicesFolderPath);
 
         for (int i = 0; i < invoicesPaths.size(); i++) {
             final String expectedXmlInvoiceFilePath = invoicesPaths.get(i).toString();
@@ -85,10 +83,12 @@ class FatturaElettronicaSerializationRoundTripTest extends AbstractXmlSerializat
      * @param invoicesFolderPath the folder path where to parse files
      * @return The stream of parsed invoices
      */
-    private Stream<FatturaElettronica> parseInvoicesInFolder(final Path invoicesFolderPath) {
-        return getInvoicesFromFolder(invoicesFolderPath)
-                .stream()
-                .map(this::parseFromXmlFile);
+    private List<FatturaElettronica> parseInvoicesInFolder(final Path invoicesFolderPath) {
+        final List<FatturaElettronica> list = new ArrayList<>();
+        for (final File file : getInvoicesFromFolder(invoicesFolderPath)) {
+            list.add(parseFromXmlFile(file));
+        }
+        return list;
     }
 
     /**

--- a/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiCassaPrevidenzialeTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiCassaPrevidenzialeTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**

--- a/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiDDTTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiDDTTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 

--- a/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiGeneraliDocumentoTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiGeneraliDocumentoTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 

--- a/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiGeneraliTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiGeneraliTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;

--- a/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/products/DatiBeniServiziTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/products/DatiBeniServiziTest.java
@@ -8,9 +8,10 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.util.Collections;
 
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -251,7 +252,7 @@ class DatiBeniServiziTest extends AbstractXmlSerializationTest {
         final DatiBeniServizi testObj =
                 new DatiBeniServizi(
                         asList(dettaglioLinee1, dettaglioLinee2),
-                        emptyList()  // !! this is not semantically correct !!
+                        Collections.<DatiRiepilogo>emptyList()  // !! this is not semantically correct !!
                         // DatiRiepilogo should always be evaluated in production code
                 );
 
@@ -279,7 +280,7 @@ class DatiBeniServiziTest extends AbstractXmlSerializationTest {
         final DatiBeniServizi testObj =
                 new DatiBeniServizi(
                         asList(dettaglioLinee1, dettaglioLinee2),
-                        emptyList()  // !! this is not semantically correct !!
+                        Collections.<DatiRiepilogo>emptyList()  // !! this is not semantically correct !!
                         // DatiRiepilogo should always be evaluated in production code
                 );
 

--- a/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/products/DettaglioLineeTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/invoicebody/products/DettaglioLineeTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 

--- a/src/test/java/com/github/siboxd/fatturapa/model/invoiceheader/buyer/CessionarioCommittenteTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/invoiceheader/buyer/CessionarioCommittenteTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**

--- a/src/test/java/com/github/siboxd/fatturapa/model/invoiceheader/fiscalagent/RappresentanteFiscaleTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/invoiceheader/fiscalagent/RappresentanteFiscaleTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**

--- a/src/test/java/com/github/siboxd/fatturapa/model/invoiceheader/supplier/CedentePrestatoreTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/invoiceheader/supplier/CedentePrestatoreTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**

--- a/src/test/java/com/github/siboxd/fatturapa/model/invoiceheader/transmissiondata/DatiTrasmissioneTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/model/invoiceheader/transmissiondata/DatiTrasmissioneTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**

--- a/src/test/java/com/github/siboxd/fatturapa/testutils/AbstractTestWithTemporaryFiles.java
+++ b/src/test/java/com/github/siboxd/fatturapa/testutils/AbstractTestWithTemporaryFiles.java
@@ -28,7 +28,9 @@ public abstract class AbstractTestWithTemporaryFiles {
 
     @AfterEach
     protected void tearDown() {
-        toDeleteTempFilePaths.stream().map(Path::toFile).forEach(FileUtils::deleteQuietly);
+        for (final Path toDeleteTempFilePath : toDeleteTempFilePaths) {
+            FileUtils.deleteQuietly(toDeleteTempFilePath.toFile());
+        }
         toDeleteTempFilePaths.clear();
     }
 

--- a/src/test/java/com/github/siboxd/fatturapa/testutils/AbstractXmlSerializationTest.java
+++ b/src/test/java/com/github/siboxd/fatturapa/testutils/AbstractXmlSerializationTest.java
@@ -7,6 +7,7 @@ import org.simpleframework.xml.core.Persister;
 import java.nio.file.Path;
 
 import static com.github.siboxd.fatturapa.testutils.AssertionUtils.assertFileLinesTrimmedEquals;
+import static com.github.siboxd.fatturapa.testutils.ResourceResolver.resolveResourcePath;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -14,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  *
  * @author Enrico
  */
-public abstract class AbstractXmlSerializationTest extends AbstractTestWithTemporaryFiles implements ResourceResolver {
+public abstract class AbstractXmlSerializationTest extends AbstractTestWithTemporaryFiles {
 
     protected Serializer persister;
 

--- a/src/test/java/com/github/siboxd/fatturapa/testutils/AssertionUtils.java
+++ b/src/test/java/com/github/siboxd/fatturapa/testutils/AssertionUtils.java
@@ -31,7 +31,7 @@ public final class AssertionUtils {
         final List<String> actualLines = Files.readAllLines(actualFilePath, StandardCharsets.UTF_8);
 
         assertEquals(expectedLines.size(), actualLines.size(),
-                () -> "Line count not matching for " + expectedFilePath + " file!!");
+                "Line count not matching for " + expectedFilePath + " file!!");
 
         for (int i = 0; i < expectedLines.size(); i++) {
             final String expected = expectedLines.get(i).trim();

--- a/src/test/java/com/github/siboxd/fatturapa/testutils/AssertionUtils.java
+++ b/src/test/java/com/github/siboxd/fatturapa/testutils/AssertionUtils.java
@@ -1,7 +1,5 @@
 package com.github.siboxd.fatturapa.testutils;
 
-import com.google.common.collect.Streams;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -15,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @author Enrico
  */
-@SuppressWarnings("UnstableApiUsage")
 public final class AssertionUtils {
 
     /**
@@ -36,9 +33,11 @@ public final class AssertionUtils {
         assertEquals(expectedLines.size(), actualLines.size(),
                 () -> "Line count not matching for " + expectedFilePath + " file!!");
 
-        Streams.forEachPair(expectedLines.stream(), actualLines.stream(),
-                (expected, actual) ->
-                        assertEquals(expected.trim(), actual.trim(),
-                                () -> "At line " + (expectedLines.indexOf(expected) + 1)));
+        for (int i = 0; i < expectedLines.size(); i++) {
+            final String expected = expectedLines.get(i).trim();
+            final String actual = actualLines.get(i).trim();
+
+            assertEquals(expected, actual, "At line " + (i + 1));
+        }
     }
 }

--- a/src/test/java/com/github/siboxd/fatturapa/testutils/ResourceResolver.java
+++ b/src/test/java/com/github/siboxd/fatturapa/testutils/ResourceResolver.java
@@ -1,11 +1,12 @@
 package com.github.siboxd.fatturapa.testutils;
 
-import com.google.common.io.Resources;
-
 import java.io.File;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Utility interface that adds the resource loading feature into classes
@@ -21,9 +22,12 @@ public interface ResourceResolver {
      * @return the resource path
      * @throws URISyntaxException if there are problems converting the complete path
      */
-    @SuppressWarnings("UnstableApiUsage")
     default Path resolveResourcePath(final String resourcePath) throws URISyntaxException {
-        return Paths.get(Resources.getResource(resourcePath).toURI());
+        final URL resourceUrl = requireNonNull(
+                getClass().getClassLoader().getResource(resourcePath),
+                "Resource not found " + resourcePath
+        );
+        return Paths.get(resourceUrl.toURI());
     }
 
     /**
@@ -34,8 +38,7 @@ public interface ResourceResolver {
      * @return the resource path
      * @throws URISyntaxException if there are problems converting the complete path
      */
-    @SuppressWarnings("UnstableApiUsage")
     default Path resolveResourcePath(final String basePath, final String resourcePath) throws URISyntaxException {
-        return Paths.get(Resources.getResource(basePath + File.separator + resourcePath).toURI());
+        return resolveResourcePath(basePath + File.separator + resourcePath);
     }
 }

--- a/src/test/java/com/github/siboxd/fatturapa/testutils/ResourceResolver.java
+++ b/src/test/java/com/github/siboxd/fatturapa/testutils/ResourceResolver.java
@@ -13,7 +13,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @author Enrico
  */
-public interface ResourceResolver {
+public final class ResourceResolver {
 
     /**
      * Resolves a resource path
@@ -22,9 +22,9 @@ public interface ResourceResolver {
      * @return the resource path
      * @throws URISyntaxException if there are problems converting the complete path
      */
-    default Path resolveResourcePath(final String resourcePath) throws URISyntaxException {
+    public static Path resolveResourcePath(final String resourcePath) throws URISyntaxException {
         final URL resourceUrl = requireNonNull(
-                getClass().getClassLoader().getResource(resourcePath),
+                ResourceResolver.class.getClassLoader().getResource(resourcePath),
                 "Resource not found " + resourcePath
         );
         return Paths.get(resourceUrl.toURI());
@@ -38,7 +38,7 @@ public interface ResourceResolver {
      * @return the resource path
      * @throws URISyntaxException if there are problems converting the complete path
      */
-    default Path resolveResourcePath(final String basePath, final String resourcePath) throws URISyntaxException {
+    public static Path resolveResourcePath(final String basePath, final String resourcePath) throws URISyntaxException {
         return resolveResourcePath(basePath + File.separator + resourcePath);
     }
 }


### PR DESCRIPTION
# v0.3.1

- Restored *Android compatibility* with API Level below 24
    - Removed Java 8+ code replacing with plain Java 7 alternative
    - Removed unused *apache commons-lang3* library 
    - Removed *guava* dependency as it was unnecessary