### PR TITLE
[Hotfix] XML Tag Ordering fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.github.siboxd'
-version '0.3.1'
+version '0.3.2'
 
 sourceCompatibility = 1.7
 

--- a/src/main/java/com/github/siboxd/fatturapa/model/FatturaElettronica.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/FatturaElettronica.java
@@ -32,7 +32,7 @@ import static com.github.siboxd.fatturapa.model.utils.Lists.defensiveCopy;
 })
 @Namespace(prefix = "p", reference = "http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2")
 @Order(elements = {"FatturaElettronicaHeader", "FatturaElettronicaBody", "Signature"},
-        attributes = {"schemaLocation", "versione"})
+        attributes = {"versione", "schemaLocation"})
 public final class FatturaElettronica {
 
     @Attribute(name = "schemaLocation", required = false)

--- a/src/main/java/com/github/siboxd/fatturapa/model/FatturaElettronica.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/FatturaElettronica.java
@@ -12,6 +12,7 @@ import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Namespace;
 import org.simpleframework.xml.NamespaceList;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 import java.util.Collections;
@@ -30,6 +31,8 @@ import static com.github.siboxd.fatturapa.model.utils.Lists.defensiveCopy;
         @Namespace(prefix = "xsi", reference = "http://www.w3.org/2001/XMLSchema-instance")
 })
 @Namespace(prefix = "p", reference = "http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2")
+@Order(elements = {"FatturaElettronicaHeader", "FatturaElettronicaBody", "Signature"},
+        attributes = {"schemaLocation", "versione"})
 public final class FatturaElettronica {
 
     @Attribute(name = "schemaLocation", required = false)

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/Allegati.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/Allegati.java
@@ -3,6 +3,7 @@ package com.github.siboxd.fatturapa.model.invoicebody;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -19,6 +20,8 @@ import org.simpleframework.xml.Root;
  * </ul>
  */
 @Root(name = "Allegati")
+@Order(elements = {"NomeAttachment", "AlgoritmoCompressione", "FormatoAttachment",
+        "DescrizioneAttachment", "Attachment"})
 public final class Allegati {
 
     @Element(name = "NomeAttachment")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/DatiVeicoli.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/DatiVeicoli.java
@@ -2,6 +2,7 @@ package com.github.siboxd.fatturapa.model.invoicebody;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -9,6 +10,7 @@ import org.simpleframework.xml.Root;
  * Contains the information of the vehicles object of the invoice
  */
 @Root(name = "DatiVeicoli")
+@Order(elements = {"Data", "TotalePercorso"})
 public final class DatiVeicoli {
 
     @Element(name = "Data")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/FatturaElettronicaBody.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/FatturaElettronicaBody.java
@@ -8,6 +8,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 import java.util.Collections;
@@ -22,6 +23,7 @@ import static com.github.siboxd.fatturapa.model.utils.Lists.defensiveCopy;
  * of invoices the lot itself must be repeated for each invoice.
  */
 @Root(name = "FatturaElettronicaBody")
+@Order(elements = {"DatiGenerali", "DatiBeniServizi", "DatiVeicoli", "DatiPagamento", "Allegati"})
 public final class FatturaElettronicaBody {
 
     @Element(name = "DatiGenerali")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/ScontoMaggiorazione.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/ScontoMaggiorazione.java
@@ -5,6 +5,7 @@ import com.github.siboxd.fatturapa.model.invoicebody.general.TipoScontoMaggioraz
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -12,6 +13,7 @@ import org.simpleframework.xml.Root;
  * Describes the discounts or surcharges applied on the total invoice
  */
 @Root(name = "ScontoMaggiorazione")
+@Order(elements = {"Tipo", "Percentuale", "Importo"})
 public final class ScontoMaggiorazione {
 
     @Element(name = "Tipo")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiBollo.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiBollo.java
@@ -2,6 +2,7 @@ package com.github.siboxd.fatturapa.model.invoicebody.general;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -9,6 +10,7 @@ import org.simpleframework.xml.Root;
  * Describes stamp duty
  */
 @Root(name = "DatiBollo")
+@Order(elements = {"BolloVirtuale", "ImportoBollo"})
 public final class DatiBollo {
 
     @Element(name = "BolloVirtuale")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiCassaPrevidenziale.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiCassaPrevidenziale.java
@@ -6,6 +6,7 @@ import com.github.siboxd.fatturapa.model.invoicebody.Ritenuta;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -13,6 +14,8 @@ import org.simpleframework.xml.Root;
  * Describes the social security contribution to be paid
  */
 @Root(name = "DatiCassaPrevidenziale")
+@Order(elements = {"TipoCassa", "AlCassa", "ImportoContributoCassa", "ImponibileCassa", "AliquotaIVA",
+        "Ritenuta", "Natura", "RiferimentoAmministrazione"})
 public final class DatiCassaPrevidenziale {
 
     @Element(name = "TipoCassa")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiDDT.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiDDT.java
@@ -4,6 +4,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 import java.util.ArrayList;
@@ -17,6 +18,7 @@ import static com.github.siboxd.fatturapa.model.utils.Lists.defensiveCopy;
  * Describes the data of the Transportation Documents linked to the invoice
  */
 @Root(name = "DatiDDT")
+@Order(elements = {"NumeroDDT", "DataDDT", "RiferimentoNumeroLinea"})
 public final class DatiDDT {
 
     @Element(name = "NumeroDDT")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiDocumentiCorrelati.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiDocumentiCorrelati.java
@@ -4,6 +4,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 import java.util.Collections;
@@ -16,6 +17,8 @@ import static com.github.siboxd.fatturapa.model.utils.Lists.defensiveCopy;
  * Describes the possible documents related to an invoice
  */
 @Root(name = "DatiDocumentiCorrelati")
+@Order(elements = {"RiferimentoNumeroLinea", "IdDocumento", "Data", "NumItem", "CodiceCommessaConvenzione",
+        "CodiceCUP", "CodiceCIG"})
 public final class DatiDocumentiCorrelati {
 
     @ElementList(name = "RiferimentoNumeroLinea", entry = "RiferimentoNumeroLinea", inline = true, required = false, empty = false)

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiGenerali.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiGenerali.java
@@ -4,6 +4,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 import java.util.Collections;
@@ -16,6 +17,8 @@ import static com.github.siboxd.fatturapa.model.utils.Lists.defensiveCopy;
  * This block contains the general data of the invoice document and related documents.
  */
 @Root(name = "DatiGenerali")
+@Order(elements = {"DatiGeneraliDocumento", "DatiOrdineAcquisto", "DatiContratto", "DatiConvenzione",
+        "DatiRicezione", "DatiFattureCollegate", "DatiSAL", "DatiDDT", "DatiTrasporto", "FatturaPrincipale"})
 public final class DatiGenerali {
 
     @Element(name = "DatiGeneraliDocumento")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiGeneraliDocumento.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiGeneraliDocumento.java
@@ -6,6 +6,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 import java.util.Collections;
@@ -18,6 +19,9 @@ import static com.github.siboxd.fatturapa.model.utils.Lists.defensiveCopy;
  * This block contains the general data of the invoice document.
  */
 @Root(name = "DatiGeneraliDocumento")
+@Order(elements = {"TipoDocumento", "Divisa", "Data", "Numero", "DatiRitenuta", "DatiBollo",
+        "DatiCassaPrevidenziale", "ScontoMaggiorazione", "ImportoTotaleDocumento", "Arrotondamento",
+        "Causale", "Art73"})
 public final class DatiGeneraliDocumento {
 
     @Element(name = "TipoDocumento")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiRitenuta.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiRitenuta.java
@@ -2,6 +2,7 @@ package com.github.siboxd.fatturapa.model.invoicebody.general;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -9,6 +10,7 @@ import org.simpleframework.xml.Root;
  * Describes the withholding tax as a down payment or on a permanent basis
  */
 @Root(name = "DatiRitenuta")
+@Order(elements = {"TipoRitenuta", "ImportoRitenuta", "AliquotaRitenuta", "CausalePagamento"})
 public final class DatiRitenuta {
 
     @Element(name = "TipoRitenuta")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiTrasporto.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/DatiTrasporto.java
@@ -5,6 +5,7 @@ import com.github.siboxd.fatturapa.model.invoicecommon.Indirizzo;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -12,6 +13,9 @@ import org.simpleframework.xml.Root;
  * Block of data describing the transport of the transferred goods
  */
 @Root(name = "DatiTrasporto")
+@Order(elements = {"DatiAnagraficiVettore", "MezzoTrasporto", "CausaleTrasporto", "NumeroColli",
+        "Descrizione", "UnitaMisuraPeso", "PesoLordo", "PesoNetto", "DataOraRitiro", "DataInizioTrasporto",
+        "TipoResa", "IndirizzoResa", "DataOraConsegna"})
 public final class DatiTrasporto {
 
     @Element(name = "DatiAnagraficiVettore", required = false)

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/FatturaPrincipale.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/general/FatturaPrincipale.java
@@ -2,6 +2,7 @@ package com.github.siboxd.fatturapa.model.invoicebody.general;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -10,6 +11,7 @@ import org.simpleframework.xml.Root;
  * by hauliers on behalf of the same client
  */
 @Root(name = "FatturaPrincipale")
+@Order(elements = {"NumeroFatturaPrincipale", "DataFatturaPrincipale"})
 public final class FatturaPrincipale {
 
     @Element(name = "NumeroFatturaPrincipale")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/payment/DatiPagamento.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/payment/DatiPagamento.java
@@ -3,6 +3,7 @@ package com.github.siboxd.fatturapa.model.invoicebody.payment;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 import java.util.Collections;
@@ -15,6 +16,7 @@ import static com.github.siboxd.fatturapa.model.utils.Lists.defensiveCopy;
  * It contains information related to the payment in terms of conditions, methods and terms
  */
 @Root(name = "DatiPagamento")
+@Order(elements = {"CondizioniPagamento","DettaglioPagamento"})
 public final class DatiPagamento {
 
     @Element(name = "CondizioniPagamento")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/payment/DettaglioPagamento.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/payment/DettaglioPagamento.java
@@ -3,6 +3,7 @@ package com.github.siboxd.fatturapa.model.invoicebody.payment;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -10,6 +11,12 @@ import org.simpleframework.xml.Root;
  * Contains the details to make the payment
  */
 @Root(name = "DettaglioPagamento")
+@Order(elements = {"Beneficiario", "ModalitaPagamento", "DataRiferimentoTerminiPagamento",
+        "GiorniTerminiPagamento", "DataScadenzaPagamento", "ImportoPagamento", "CodUfficioPostale",
+        "CognomeQuietanzante", "NomeQuietanzante", "CFQuietanzante", "TitoloQuietanzante",
+        "IstitutoFinanziario", "IBAN", "ABI", "CAB", "BIC", "ScontoPagamentoAnticipato",
+        "DataLimitePagamentoAnticipato", "PenalitaPagamentiRitardati", "DataDecorrenzaPenale",
+        "CodicePagamento"})
 public final class DettaglioPagamento {
 
     @Element(name = "Beneficiario", required = false)

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/products/AltriDatiGestionali.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/products/AltriDatiGestionali.java
@@ -3,6 +3,7 @@ package com.github.siboxd.fatturapa.model.invoicebody.products;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -11,6 +12,7 @@ import org.simpleframework.xml.Root;
  * to refer to each individual detail line of the document itself, having managerial or other usefulness
  */
 @Root(name = "AltriDatiGestionali")
+@Order(elements = {"TipoDato", "RiferimentoTesto", "RiferimentoNumero", "RiferimentoData"})
 public final class AltriDatiGestionali {
 
     @Element(name = "TipoDato")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/products/CodiceArticolo.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/products/CodiceArticolo.java
@@ -2,6 +2,7 @@ package com.github.siboxd.fatturapa.model.invoicebody.products;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -9,6 +10,7 @@ import org.simpleframework.xml.Root;
  * Describes the identification of a product based on a standard
  */
 @Root(name = "CodiceArticolo")
+@Order(elements = {"CodiceTipo", "CodiceValore"})
 public final class CodiceArticolo {
 
     @Element(name = "CodiceTipo")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/products/DatiBeniServizi.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/products/DatiBeniServizi.java
@@ -2,6 +2,7 @@ package com.github.siboxd.fatturapa.model.invoicebody.products;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 import java.util.Collections;
@@ -15,6 +16,7 @@ import static com.github.siboxd.fatturapa.model.utils.Lists.defensiveCopy;
  * the transfer of goods or the provision of services.
  */
 @Root(name = "DatiBeniServizi")
+@Order(elements = {"DettaglioLinee", "DatiRiepilogo"})
 public final class DatiBeniServizi {
 
     @ElementList(name = "DettaglioLinee", entry = "DettaglioLinee", inline = true)

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/products/DatiRiepilogo.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/products/DatiRiepilogo.java
@@ -5,6 +5,7 @@ import com.github.siboxd.fatturapa.model.invoicebody.Natura;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -14,6 +15,8 @@ import org.simpleframework.xml.Root;
  * of payment of the tax depend on the application of the split of payments
  */
 @Root(name = "DatiRiepilogo")
+@Order(elements = {"AliquotaIVA", "Natura", "SpeseAccessorie", "Arrotondamento", "ImponibileImporto",
+        "Imposta", "EsigibilitaIVA", "RiferimentoNormativo"})
 public final class DatiRiepilogo {
 
     @Element(name = "AliquotaIVA")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/products/DettaglioLinee.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicebody/products/DettaglioLinee.java
@@ -8,6 +8,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 import java.util.Collections;
@@ -20,6 +21,9 @@ import static com.github.siboxd.fatturapa.model.utils.Lists.defensiveCopy;
  * Denotes a detail line of the document
  */
 @Root(name = "DettaglioLinee")
+@Order(elements = {"NumeroLinea", "TipoCessionePrestazione", "CodiceArticolo", "Descrizione", "Quantita",
+        "UnitaMisura", "DataInizioPeriodo", "DataFinePeriodo", "PrezzoUnitario", "ScontoMaggiorazione",
+        "PrezzoTotale", "AliquotaIVA", "Ritenuta", "Natura", "RiferimentoAmministrazione", "AltriDatiGestionali"})
 public final class DettaglioLinee {
 
     @Element(name = "NumeroLinea")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicecommon/Anagrafica.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicecommon/Anagrafica.java
@@ -3,6 +3,7 @@ package com.github.siboxd.fatturapa.model.invoicecommon;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -10,6 +11,7 @@ import org.simpleframework.xml.Root;
  * Contains personal data of a subject
  */
 @Root(name = "Anagrafica")
+@Order(elements = {"Denominazione", "Nome", "Cognome", "Titolo", "CodEORI"})
 public final class Anagrafica extends AbstractNaming {
 
     @Element(name = "Titolo", required = false)

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicecommon/IdFiscale.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicecommon/IdFiscale.java
@@ -2,6 +2,7 @@ package com.github.siboxd.fatturapa.model.invoicecommon;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -9,6 +10,7 @@ import org.simpleframework.xml.Root;
  * It is used to identify the subject that interacts with the Interchange System.<br><br>
  */
 @Root(name = "IdFiscale")
+@Order(elements = {"IdPaese", "IdCodice"})
 public final class IdFiscale {
 
     @Element(name = "IdPaese")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoicecommon/Indirizzo.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoicecommon/Indirizzo.java
@@ -3,6 +3,7 @@ package com.github.siboxd.fatturapa.model.invoicecommon;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -10,6 +11,7 @@ import org.simpleframework.xml.Root;
  * Contains physical addressing information
  */
 @Root(name = "Indirizzo")
+@Order(elements = {"Indirizzo", "NumeroCivico", "CAP", "Comune", "Provincia", "Nazione"})
 public final class Indirizzo {
 
     @Element(name = "Indirizzo")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/FatturaElettronicaHeader.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/FatturaElettronicaHeader.java
@@ -9,6 +9,7 @@ import com.github.siboxd.fatturapa.model.invoiceheader.transmissiondata.DatiTras
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -19,6 +20,8 @@ import org.simpleframework.xml.Root;
  * electronically and the recipient to which the file must be delivered.<br><br>
  */
 @Root(name = "FatturaElettronicaHeader")
+@Order(elements = {"DatiTrasmissione", "CedentePrestatore", "RappresentanteFiscale", "CessionarioCommittente",
+        "TerzoIntermediarioOSoggettoEmittente", "SoggettoEmittente"})
 public final class FatturaElettronicaHeader {
 
     @Element(name = "DatiTrasmissione")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/buyer/CessionarioCommittente.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/buyer/CessionarioCommittente.java
@@ -5,6 +5,7 @@ import com.github.siboxd.fatturapa.model.invoicecommon.Indirizzo;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -12,6 +13,7 @@ import org.simpleframework.xml.Root;
  * This block contains the data relating to the transferee or customer of the good/service being billed.
  */
 @Root(name = "CessionarioCommittente")
+@Order(elements = {"DatiAnagrafici", "Sede", "StabileOrganizzazione", "RappresentanteFiscale"})
 public final class CessionarioCommittente {
 
     @Element(name = "DatiAnagrafici")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/supplier/CedentePrestatore.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/supplier/CedentePrestatore.java
@@ -5,6 +5,7 @@ import com.github.siboxd.fatturapa.model.invoicecommon.Indirizzo;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -12,6 +13,8 @@ import org.simpleframework.xml.Root;
  * This block contains the data relating to the seller of the good / service being billed.
  */
 @Root(name = "CedentePrestatore")
+@Order(elements = {"DatiAnagrafici", "Sede", "StabileOrganizzazione", "IscrizioneREA", "Contatti",
+        "RiferimentoAmministrazione"})
 public final class CedentePrestatore {
 
     @Element(name = "DatiAnagrafici")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/supplier/IscrizioneREA.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/supplier/IscrizioneREA.java
@@ -3,6 +3,7 @@ package com.github.siboxd.fatturapa.model.invoiceheader.supplier;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -11,6 +12,7 @@ import org.simpleframework.xml.Root;
  * at the company registry office
  */
 @Root(name = "IscrizioneREA")
+@Order(elements = {"Ufficio", "NumeroREA", "CapitaleSociale", "SocioUnico", "StatoLiquidazione"})
 public final class IscrizioneREA {
 
     @Element(name = "Ufficio")

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/transmissiondata/ContattiTrasmittente.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/transmissiondata/ContattiTrasmittente.java
@@ -3,6 +3,7 @@ package com.github.siboxd.fatturapa.model.invoiceheader.transmissiondata;
 import com.github.siboxd.fatturapa.model.invoicecommon.AbstractContatti;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -10,6 +11,7 @@ import org.simpleframework.xml.Root;
  * It is used to provide additional information useful for contacting the transmitting subject.
  */
 @Root(name = "ContattiTrasmittente")
+@Order(elements = {"Telefono", "Email"})
 public final class ContattiTrasmittente extends AbstractContatti {
 
     /**

--- a/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/transmissiondata/DatiTrasmissione.java
+++ b/src/main/java/com/github/siboxd/fatturapa/model/invoiceheader/transmissiondata/DatiTrasmissione.java
@@ -5,6 +5,7 @@ import com.github.siboxd.fatturapa.model.invoicecommon.IdFiscale;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 
 
@@ -13,6 +14,8 @@ import org.simpleframework.xml.Root;
  * of the electronic document to the recipient.<br><br>
  */
 @Root(name = "DatiTrasmissione")
+@Order(elements = {"IdTrasmittente", "ProgressivoInvio", "FormatoTrasmissione", "CodiceDestinatario",
+        "ContattiTrasmittente", "PECDestinatario"})
 public final class DatiTrasmissione {
 
     @Element(name = "IdTrasmittente")

--- a/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPA01.xml
+++ b/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPA01.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:FatturaElettronica xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" versione="FPA12" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<p:FatturaElettronica versione="FPA12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <FatturaElettronicaHeader>
     <DatiTrasmissione>
       <IdTrasmittente>

--- a/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPA02.xml
+++ b/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPA02.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:FatturaElettronica xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" versione="FPA12" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<p:FatturaElettronica versione="FPA12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <FatturaElettronicaHeader>
     <DatiTrasmissione>
       <IdTrasmittente>

--- a/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPA03.xml
+++ b/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPA03.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:FatturaElettronica xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" versione="FPA12" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<p:FatturaElettronica versione="FPA12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <FatturaElettronicaHeader>
     <DatiTrasmissione>
       <IdTrasmittente>

--- a/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPR01.xml
+++ b/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPR01.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:FatturaElettronica xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" versione="FPR12" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<p:FatturaElettronica versione="FPR12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <FatturaElettronicaHeader>
     <DatiTrasmissione>
       <IdTrasmittente>

--- a/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPR02.xml
+++ b/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPR02.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:FatturaElettronica xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" versione="FPR12" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<p:FatturaElettronica versione="FPR12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <FatturaElettronicaHeader>
 <DatiTrasmissione>
 <IdTrasmittente>

--- a/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPR03.xml
+++ b/src/test/resources/complete_invoice_examples/official_examples/IT01234567890_FPR03.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:FatturaElettronica xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" versione="FPR12" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<p:FatturaElettronica versione="FPR12" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <FatturaElettronicaHeader>
     <DatiTrasmissione>
       <IdTrasmittente>


### PR DESCRIPTION
# XML tag ordering Fix

Added `@Order` annotation all over the classes to avoid unexpected *XML tag* ordering, that made [FatturaPA online checks](https://sdi.fatturapa.gov.it/SdI2FatturaPAWeb/AccediAlServizioAction.do?pagina=controlla_fattura) fail.